### PR TITLE
Implement alarm scheduling and drawers

### DIFF
--- a/app/src/main/java/com/example/timeapp/presentation/alarm/AlarmScreen.kt
+++ b/app/src/main/java/com/example/timeapp/presentation/alarm/AlarmScreen.kt
@@ -1,6 +1,7 @@
 package com.example.timeapp.presentation.alarm
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,12 +10,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -23,8 +28,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.snapshotFlow
+import com.example.timeapp.presentation.timer.HOURS
+import com.example.timeapp.presentation.timer.MINUTES
+import kotlinx.coroutines.flow.distinctUntilChanged
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+
+private val ITEM_HEIGHT = 50.dp
+private const val VISIBLE_COUNT = 3
+private val CENTER_OFFSET = VISIBLE_COUNT / 2
 
 @Composable
 fun AlarmScreen(
@@ -32,6 +47,7 @@ fun AlarmScreen(
 ) {
     var isAddingAlarm by remember { mutableStateOf(false) }
     var isEditingAlarm by remember { mutableStateOf(false) }
+    var editingAlarmId by remember { mutableStateOf<String?>(null) }
 
     Column(
         modifier = Modifier
@@ -91,6 +107,7 @@ fun AlarmScreen(
                             onClick = {
                                 isAddingAlarm = false
                                 isEditingAlarm = true
+                                editingAlarmId = alarm.id
                             }
                         ) {
                             Text("Edit")
@@ -123,24 +140,186 @@ fun AlarmScreen(
         }
 
         // Drawers
+        if (isAddingAlarm) {
+            AddAlarmDrawer(
+                onDismiss = { isAddingAlarm = false },
+                onCreate = {
+                    vm.addNewAlarm(it, true)
+                    isAddingAlarm = false
+                }
+            )
+        }
+
+        if (isEditingAlarm) {
+            val alarm = vm.alarms.firstOrNull { it.id == editingAlarmId }
+            if (alarm != null) {
+                EditAlarmDrawer(
+                    alarm = alarm,
+                    onDismiss = {
+                        isEditingAlarm = false
+                        editingAlarmId = null
+                    },
+                    onConfirm = { time ->
+                        vm.editAlarm(alarm.id, time)
+                        if (alarm.activated) {
+                            vm.activateAlarm(alarm.id)
+                        }
+                        isEditingAlarm = false
+                        editingAlarmId = null
+                    }
+                )
+            }
+        }
 
     }
 }
 
 @Composable
-fun AddAlarmDrawer() {
-    // Title
-    // Dropdown menu for select hour and minute of alarm time
-    // Create button
-    // Close button
+fun AddAlarmDrawer(
+    onDismiss: () -> Unit,
+    onCreate: (LocalTime) -> Unit
+) {
+    val hourState = rememberLazyListState()
+    val minuteState = rememberLazyListState()
+
+    var selectedHour by remember { mutableIntStateOf(0) }
+    var selectedMinute by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(hourState) {
+        snapshotFlow { hourState.firstVisibleItemIndex }
+            .distinctUntilChanged()
+            .collect { idx ->
+                selectedHour = HOURS.getOrElse(idx) { HOURS.last() }
+            }
+    }
+    LaunchedEffect(minuteState) {
+        snapshotFlow { minuteState.firstVisibleItemIndex }
+            .distinctUntilChanged()
+            .collect { idx ->
+                selectedMinute = MINUTES.getOrElse(idx) { MINUTES.last() }
+            }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("Add Alarm", fontSize = 20.sp)
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TimePickerColumn(state = hourState, items = HOURS)
+                Text(":", fontSize = 24.sp)
+                TimePickerColumn(state = minuteState, items = MINUTES)
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    onCreate(LocalTime.of(selectedHour, selectedMinute))
+                }
+            ) { Text("Create") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = Color.LightGray, contentColor = Color.Black),
+                onClick = onDismiss
+            ) { Text("Close") }
+        }
+    }
 }
 
 @Composable
-fun EditAlarmDrawer() {
-    // Title
-    // Dropdown menu for select hour and minute of alarm time
-    // Confirm button
-    // Close button
+fun EditAlarmDrawer(
+    alarm: Alarm,
+    onDismiss: () -> Unit,
+    onConfirm: (LocalTime) -> Unit
+) {
+    val hourState = rememberLazyListState(initialFirstVisibleItemIndex = alarm.alarmTime.hour)
+    val minuteState = rememberLazyListState(initialFirstVisibleItemIndex = alarm.alarmTime.minute)
+
+    var selectedHour by remember { mutableIntStateOf(alarm.alarmTime.hour) }
+    var selectedMinute by remember { mutableIntStateOf(alarm.alarmTime.minute) }
+
+    LaunchedEffect(hourState) {
+        snapshotFlow { hourState.firstVisibleItemIndex }
+            .distinctUntilChanged()
+            .collect { idx ->
+                selectedHour = HOURS.getOrElse(idx) { HOURS.last() }
+            }
+    }
+    LaunchedEffect(minuteState) {
+        snapshotFlow { minuteState.firstVisibleItemIndex }
+            .distinctUntilChanged()
+            .collect { idx ->
+                selectedMinute = MINUTES.getOrElse(idx) { MINUTES.last() }
+            }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("Edit Alarm", fontSize = 20.sp)
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TimePickerColumn(state = hourState, items = HOURS)
+                Text(":", fontSize = 24.sp)
+                TimePickerColumn(state = minuteState, items = MINUTES)
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    onConfirm(LocalTime.of(selectedHour, selectedMinute))
+                }
+            ) { Text("Confirm") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = Color.LightGray, contentColor = Color.Black),
+                onClick = onDismiss
+            ) { Text("Close") }
+        }
+    }
+}
+
+@Composable
+private fun TimePickerColumn(state: LazyListState, items: List<Int>) {
+    LazyColumn(
+        state = state,
+        modifier = Modifier.weight(1f),
+        contentPadding = PaddingValues(vertical = ITEM_HEIGHT * CENTER_OFFSET),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        items(items.size) { i ->
+            Box(
+                modifier = Modifier
+                    .height(ITEM_HEIGHT)
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(String.format("%02d", items[i]), fontSize = 20.sp)
+            }
+        }
+    }
 }
 
 private fun formatLocalTime(time: LocalTime): String {

--- a/app/src/main/java/com/example/timeapp/presentation/alarm/AlarmViewModel.kt
+++ b/app/src/main/java/com/example/timeapp/presentation/alarm/AlarmViewModel.kt
@@ -29,12 +29,16 @@ class AlarmViewModel @Inject constructor(
         alarms.add(newAlarm)
 
         if (newAlarm.activated) {
-            // Schedule alarm
+            scheduleAlarm(newAlarm)
         }
     }
 
     fun deleteAlarm(id: String) {
-        alarms.removeIf { it.id == id }
+        val alarm = alarms.firstOrNull { it.id == id }
+        if (alarm != null) {
+            if (alarm.activated) cancelAlarm(alarm)
+            alarms.remove(alarm)
+        }
     }
 
     fun editAlarm(
@@ -43,26 +47,33 @@ class AlarmViewModel @Inject constructor(
     ) {
         val idx = alarms.indexOfFirst { it.id == id }
         alarms[idx].alarmTime = alarmTime
+        if (alarms[idx].activated) {
+            scheduleAlarm(alarms[idx])
+        }
     }
 
     fun activateAlarm(id: String) {
         val idx = alarms.indexOfFirst { it.id == id }
         alarms[idx].activated = true
-        // Schedule alarm
+        scheduleAlarm(alarms[idx])
     }
 
     fun inactivateAlarm(id: String) {
         val idx = alarms.indexOfFirst { it.id == id }
         alarms[idx].activated = false
-        // Cancel alarm
+        cancelAlarm(alarms[idx])
     }
 
-    private fun scheduleAlarm() {
-        //
+    private fun scheduleAlarm(alarm: Alarm) {
+        if (alarmScheduler.canScheduleExactAlarms()) {
+            alarmScheduler.schedule(alarm.alarmTime, alarm.id)
+        } else {
+            alarmScheduler.requestExactAlarmPermission()
+        }
     }
 
-    private fun cancelAlarm() {
-        //
+    private fun cancelAlarm(alarm: Alarm) {
+        alarmScheduler.cancel(alarm.id)
     }
 
 }

--- a/app/src/main/java/com/example/timeapp/presentation/alarm/notification/AlarmScheduler.kt
+++ b/app/src/main/java/com/example/timeapp/presentation/alarm/notification/AlarmScheduler.kt
@@ -34,13 +34,13 @@ class AlarmScheduler @Inject constructor(private  val context: Context) {
         }
     }
 
-    fun schedule(alarmTime: LocalTime) {
+    fun schedule(alarmTime: LocalTime, id: String) {
 
         val intent = Intent(context, AlarmReceiver::class.java)
 
         val pending = PendingIntent.getBroadcast(
             context,
-            0,
+            id.hashCode(),
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
@@ -53,20 +53,20 @@ class AlarmScheduler @Inject constructor(private  val context: Context) {
         val triggerAt = alarmDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
         alarmManager.setExactAndAllowWhileIdle(
-            AlarmManager.ELAPSED_REALTIME_WAKEUP,
+            AlarmManager.RTC_WAKEUP,
             triggerAt,
             pending
         )
 
     }
 
-    fun cancel() {
+    fun cancel(id: String) {
 
         val intent = Intent(context, AlarmReceiver::class.java)
 
         val pending = PendingIntent.getBroadcast(
             context,
-            0,
+            id.hashCode(),
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )


### PR DESCRIPTION
## Summary
- support unique alarm scheduling via `AlarmScheduler`
- manage activation and editing logic in `AlarmViewModel`
- add bottom sheet drawers in `AlarmScreen` for creating and editing alarms

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685631dd2da08330b5347c1e3510d01d